### PR TITLE
feat: improve UX with spinners and fix edge cases

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+import {
+  checkoutWorktree,
+  createWorktree,
+  getCurrentBranch,
+  getRepoInfo,
+  listWorktrees,
+  type RepoInfo,
+  removeWorktree,
+} from "./git";
+
+const TEST_DIR = join(tmpdir(), `wt-e2e-${Date.now()}`);
+const BARE_DIR = join(TEST_DIR, "bare-repo.git");
+const REPO_DIR = join(TEST_DIR, "test-repo");
+
+let REAL_REPO_DIR: string;
+
+async function setupTestRepo() {
+  await $`mkdir -p ${TEST_DIR}`;
+
+  await $`git init --bare ${BARE_DIR}`;
+
+  await $`git clone ${BARE_DIR} ${REPO_DIR}`;
+  await $`git -C ${REPO_DIR} config user.email "test@test.com"`;
+  await $`git -C ${REPO_DIR} config user.name "Test"`;
+
+  await $`touch ${join(REPO_DIR, "file.txt")}`;
+  await $`git -C ${REPO_DIR} add .`;
+  await $`git -C ${REPO_DIR} commit -m "initial"`;
+  await $`git -C ${REPO_DIR} push -u origin main`;
+
+  await $`git -C ${REPO_DIR} checkout -b feat/test-branch`;
+  await $`touch ${join(REPO_DIR, "feature.txt")}`;
+  await $`git -C ${REPO_DIR} add .`;
+  await $`git -C ${REPO_DIR} commit -m "feature"`;
+  await $`git -C ${REPO_DIR} push -u origin feat/test-branch`;
+
+  await $`git -C ${REPO_DIR} checkout -b feat/prune-test`;
+  await $`touch ${join(REPO_DIR, "prune.txt")}`;
+  await $`git -C ${REPO_DIR} add .`;
+  await $`git -C ${REPO_DIR} commit -m "prune test"`;
+  await $`git -C ${REPO_DIR} push -u origin feat/prune-test`;
+
+  await $`git -C ${REPO_DIR} checkout main`;
+
+  REAL_REPO_DIR = await realpath(REPO_DIR);
+}
+
+describe("e2e", () => {
+  let repo: RepoInfo;
+  let originalCwd: string;
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    await setupTestRepo();
+    process.chdir(REAL_REPO_DIR);
+    repo = (await getRepoInfo())!;
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await $`rm -rf ${TEST_DIR}`.quiet();
+  });
+
+  test("getRepoInfo returns correct info", async () => {
+    expect(repo).not.toBeNull();
+    expect(repo.root).toBe(REAL_REPO_DIR);
+    expect(repo.name).toBe("test-repo");
+  });
+
+  test("getCurrentBranch returns current branch", async () => {
+    const branch = await getCurrentBranch(REAL_REPO_DIR);
+    expect(branch).toBe("main");
+  });
+
+  test("createWorktree creates new worktree", async () => {
+    const result = await createWorktree(repo, "new-feature");
+    expect(result.path).toBe(join(repo.wtDir, "new-feature"));
+    expect(await Bun.file(join(result.path, ".git")).exists()).toBe(true);
+  });
+
+  test("listWorktrees includes created worktree", async () => {
+    const worktrees = await listWorktrees(repo);
+    const names = worktrees.map((w) => w.name);
+    expect(names).toContain("main");
+    expect(names).toContain("new-feature");
+  });
+
+  test("checkoutWorktree sanitizes slashes in branch names", async () => {
+    const result = await checkoutWorktree(repo, "origin/feat/test-branch");
+    expect(result.path).toBe(join(repo.wtDir, "feat-test-branch"));
+    expect(await Bun.file(join(result.path, ".git")).exists()).toBe(true);
+  });
+
+  test("checkoutWorktree reuses existing worktree", async () => {
+    const result1 = await checkoutWorktree(repo, "origin/feat/test-branch");
+    const result2 = await checkoutWorktree(repo, "origin/feat/test-branch");
+    expect(result1.path).toBe(result2.path);
+  });
+
+  test("removeWorktree removes worktree", async () => {
+    const worktreesBefore = await listWorktrees(repo);
+    const wt = worktreesBefore.find((w) => w.name === "new-feature");
+    expect(wt).not.toBeUndefined();
+
+    await removeWorktree(repo, wt!.path);
+
+    const worktreesAfter = await listWorktrees(repo);
+    const names = worktreesAfter.map((w) => w.name);
+    expect(names).not.toContain("new-feature");
+  });
+
+  test("prune handles manually deleted worktrees", async () => {
+    const result = await checkoutWorktree(repo, "origin/feat/prune-test");
+    await $`rm -rf ${result.path}`;
+    const result2 = await checkoutWorktree(repo, "origin/feat/prune-test");
+    expect(result2.path).toBe(result.path);
+    expect(await Bun.file(join(result2.path, ".git")).exists()).toBe(true);
+  });
+});

--- a/src/post-create.ts
+++ b/src/post-create.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from "node:path";
 import { $ } from "bun";
+import { spinner } from "./ui";
 
 const EXCLUDED_DIRS = new Set([
   "node_modules",
@@ -45,17 +46,21 @@ export async function detectPackageManager(
 }
 
 async function runInstall(dir: string, pm: PackageManager): Promise<void> {
-  console.error(`Running ${pm} install...`);
+  const s = spinner(`Running ${pm} install...`);
   try {
     const proc = Bun.spawn([pm, "install"], {
       cwd: dir,
-      stdout: "inherit",
-      stderr: "inherit",
+      stdout: "ignore",
+      stderr: "ignore",
     });
     await proc.exited;
-    if (proc.exitCode !== 0) throw new Error("install failed");
+    if (proc.exitCode !== 0) {
+      s.stop(`Warning: ${pm} install failed`);
+      return;
+    }
+    s.stop();
   } catch {
-    console.error(`Warning: ${pm} install failed`);
+    s.stop(`Warning: ${pm} install failed`);
   }
 }
 

--- a/src/ui.test.ts
+++ b/src/ui.test.ts
@@ -1,38 +1,5 @@
 import { describe, expect, test } from "bun:test";
-
-// Extract testable functions - we'll need to export these
-// For now, let's recreate the fuzzy logic to test it
-
-function fuzzyMatch(
-  query: string,
-  text: string,
-): { match: boolean; score: number } {
-  if (!query) return { match: true, score: 0 };
-
-  const q = query.toLowerCase().replace(/\s+/g, "-");
-  const t = text.toLowerCase();
-
-  if (t.includes(q)) {
-    const pos = t.indexOf(q);
-    return { match: true, score: 100 - pos + (q.length / t.length) * 50 };
-  }
-
-  let qi = 0;
-  let score = 0;
-  let lastMatchPos = -1;
-
-  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] === q[qi]) {
-      score += 10;
-      if (lastMatchPos === ti - 1) score += 5;
-      lastMatchPos = ti;
-      qi++;
-    }
-  }
-
-  if (qi === q.length) return { match: true, score };
-  return { match: false, score: 0 };
-}
+import { fuzzyMatch } from "./ui";
 
 interface Worktree {
   name: string;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -36,6 +36,39 @@ const CYAN = "\x1b[36m";
 const DIM = "\x1b[90m";
 const RESET = "\x1b[0m";
 const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
+const CLEAR_LINE = "\x1b[2K\r";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+export interface Spinner {
+  update: (msg: string) => void;
+  stop: (msg?: string) => void;
+}
+
+export function spinner(message: string): Spinner {
+  let frame = 0;
+  let currentMsg = message;
+  process.stderr.write(HIDE_CURSOR);
+
+  const interval = setInterval(() => {
+    process.stderr.write(
+      `${CLEAR_LINE}${CYAN}${SPINNER_FRAMES[frame]}${RESET} ${currentMsg}`,
+    );
+    frame = (frame + 1) % SPINNER_FRAMES.length;
+  }, 80);
+
+  return {
+    update(msg: string) {
+      currentMsg = msg;
+    },
+    stop(msg?: string) {
+      clearInterval(interval);
+      process.stderr.write(CLEAR_LINE + SHOW_CURSOR);
+      if (msg) console.error(msg);
+    },
+  };
+}
 
 type Key = { name?: string; ctrl?: boolean; shift?: boolean };
 
@@ -198,7 +231,7 @@ function getCtx() {
   return _ctx;
 }
 
-function fuzzyMatch(
+export function fuzzyMatch(
   query: string,
   text: string,
 ): { match: boolean; score: number } {


### PR DESCRIPTION
## Summary
- Add loading spinners for long operations (fetch, worktree creation, npm install)
- Detect when PR branch is already checked out in main repo and cd there instead
- Sanitize branch names with slashes (`feat/foo` → `feat-foo` for directory names)
- Auto-prune stale worktree references before creating new ones
- Reuse existing worktree if path already exists

## Code cleanup
- Export `fuzzyMatch` from ui.ts to remove test duplication
- Remove redundant `branchName` variable in `createWorktree`
- Eliminate 20+ non-null assertions in index.ts with proper type narrowing

## Tests
- Add integration tests for worktree operations
- Add edge case tests for URL parsing, branch name validation, path comparison
- 119 tests passing

## Test plan
- [ ] Run `wt <github-pr-url>` when already on that branch → should cd to main repo
- [ ] Run `wt <github-pr-url>` for branch with slashes → directory should use hyphens
- [ ] Manually delete worktree folder and retry → should auto-prune and recreate
- [ ] Verify spinners display during fetch/worktree/install operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)